### PR TITLE
process_name is compatible with Plack

### DIFF
--- a/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
+++ b/lib/Plack/Handler/FCGI/Engine/ProcManager.pm
@@ -13,6 +13,13 @@ has 'pidfile' => (
     coerce   => 1,
 );
 
+has 'process_name' => (
+    init_arg => 'pm_title',
+    is       => 'ro',
+    isa      => 'Str',
+    default  => sub { 'perl-fcgi' },
+);
+
 # FCGI::ProcManager compat
 
 sub pm_manage        { (shift)->manage( @_ )        }


### PR DESCRIPTION
I installed this module as a replacement for Plack::Handler::FCGI and I noticed the process naming feature was not working.
