### PR TITLE
Fixes RT#90925 Class::MOP::load_class

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ requires 'FCGI';
 requires 'CGI::Simple';
 requires 'POSIX';
 requires 'Config::Any';
+requires 'Class::Load' => '0.20';
 
 feature 'Plack Support',
   -default           => 0,

--- a/lib/FCGI/Engine.pm
+++ b/lib/FCGI/Engine.pm
@@ -2,6 +2,7 @@ package FCGI::Engine;
 use Moose;
 
 use CGI::Simple;
+use Class::Load;
 
 our $VERSION   = '0.21';
 our $AUTHORITY = 'cpan:STEVAN';
@@ -38,7 +39,7 @@ augment 'initialize' => sub {
     my $handler_method = $self->handler_method;
     my $handler_args   = $self->handler_args_builder;
 
-    Class::MOP::load_class($handler_class) unless blessed $handler_class;
+    Class::Load::load_class($handler_class) unless blessed $handler_class;
 
     ($self->handler_class->can($handler_method))
         || confess "The handler class ("

--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -5,6 +5,7 @@ use FCGI;
 use MooseX::Daemonize::Pid::File;
 use FCGI::Engine::Types;
 use FCGI::Engine::ProcManager;
+use Class::Load;
 
 use constant DEBUG => 0;
 
@@ -121,7 +122,7 @@ sub create_proc_manager {
     my ( $self, %addtional_options ) = @_;
 
     # make sure any subclasses are loaded ...
-    Class::MOP::load_class( $self->manager );
+    Class::Load::load_class( $self->manager );
 
     return $self->manager->new({
         n_processes => $self->nproc,

--- a/lib/FCGI/Engine/Manager.pm
+++ b/lib/FCGI/Engine/Manager.pm
@@ -3,6 +3,7 @@ use Moose;
 
 use FCGI::Engine::Types;
 use FCGI::Engine::Manager::Server;
+use Class::Load;
 
 use Config::Any;
 
@@ -44,7 +45,7 @@ has '_servers' => (
         return [
             map {
                 $_->{server_class} ||= "FCGI::Engine::Manager::Server";
-                Class::MOP::load_class($_->{server_class});
+                Class::Load::load_class($_->{server_class});
                 $_->{server_class}->new(%$_);
             } @{$self->_config}
         ];

--- a/lib/FCGI/Engine/ProcManager/Constrained.pm
+++ b/lib/FCGI/Engine/ProcManager/Constrained.pm
@@ -2,6 +2,7 @@ package FCGI::Engine::ProcManager::Constrained;
 use Moose;
 use Config;
 use Try::Tiny;
+use Class::Load;
 
 extends 'FCGI::Engine::ProcManager';
 
@@ -86,7 +87,7 @@ sub _check_size {
 
 sub _load {
     my $mod = shift;
-    try { Class::MOP::load_class($mod); 1; }
+    try { Class::Load::load_class($mod); 1; }
 }
 our $USE_SMAPS;
 BEGIN {


### PR DESCRIPTION
This fixes RT#90925: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90925
