### PR TITLE
Add $request object to params passed to handle_request

### DIFF
--- a/lib/FCGI/Engine/Core.pm
+++ b/lib/FCGI/Engine/Core.pm
@@ -194,7 +194,8 @@ sub run {
         $proc_manager && $proc_manager->pre_dispatch;
 
         $self->handle_request(
-            $self->prepare_environment( $env )
+            $self->prepare_environment( $env ),
+            $request
         );
 
         $proc_manager && $proc_manager->post_dispatch;


### PR DESCRIPTION
Working with an HTML templating engine that does internal forking for long-running page requests. In order to serve this over FCGI I need the original $request object to Detach/Attach as appropriate. This lets me do so in the handle_request method.
