### PR TITLE
Fix warning from Moose::Util::TypeConstraints.

### DIFF
--- a/lib/FCGI/Engine/Types.pm
+++ b/lib/FCGI/Engine/Types.pm
@@ -60,7 +60,7 @@ subtype 'FCGI::Engine::Manager::Config'
 
 ## FCGI::Engine::ProcManager
 
-enum 'FCGI::Engine::ProcManager::Role' => qw[manager server];
+enum 'FCGI::Engine::ProcManager::Role' => [qw[manager server]];
 
 1;
 


### PR DESCRIPTION
This is the warning that I fixed:
Passing a list of values to enum is deprecated. Enum values should be wrapped
in an arrayref. at local/lib/perl5/i686-linux/Moose/Util/TypeConstraints.pm
line 440.
